### PR TITLE
Fixed corrupted "required" directives for imported modules

### DIFF
--- a/protoc-plugin/protoc-gen-lua
+++ b/protoc-plugin/protoc-gen-lua
@@ -413,7 +413,7 @@ def code_gen_file(proto_file, env, is_gen):
         lua('local module = {}\n')
         lua('local protobuf = require \'protobuf\'\n')
         for i in includes:
-            lua('local %s_pb = require \'%s_pb\')\n' % (i, i))
+            lua('local %s_pb = require \'%s_pb\'\n' % (i, i))
 
         lua('\n')
         map(lua, env.descriptor)


### PR DESCRIPTION
If you import some .proto defintion, you'll get a corrupted require directive with a single parenthese on the end.
For example, import "bar.proto"; in foo.proto will be compiled as local bar_pb = require 'bar') in foo_pb.lua